### PR TITLE
Fix "Gameplay_Key_Color.lua" script

### DIFF
--- a/Game/Scripts/Gameplay_KeyColor.lua
+++ b/Game/Scripts/Gameplay_KeyColor.lua
@@ -5,7 +5,7 @@ local Gameplay_KeyColor =
     color = nil,
 }
 
-function Gameplay_KeyColor:OnStart()
+function Gameplay_KeyColor:OnAwake()
     self.materialRenderer = Scenes.GetCurrentScene():FindActorByName("Key Model"):GetMaterialRenderer()
     self.light = Scenes.GetCurrentScene():FindActorByName("Key Light"):GetLight()
 


### PR DESCRIPTION
Fix https://github.com/Overload-Technologies/Cargo-Demo/issues/12.

The color should be set in `OnAwake` instead of `OnStart` because another script is trying to access the light color in `OnStart` as well. Resulting in Undefined Behavior which breaks the final door enigma.

Prior to https://github.com/Overload-Technologies/Overload/pull/437 there was no issues even though we didn't have any script ordering, it was just luck.